### PR TITLE
Print token id alongside token

### DIFF
--- a/src/generation.py
+++ b/src/generation.py
@@ -129,6 +129,10 @@ class Generator:
 
             if print_generation and verbose:
                 print_rank_0(
+                    f"{new_idx.item()}",
+                    end="-",
+                )
+                print_rank_0(
                     f"{self.tokenizer.detokenize([new_idx.item()])}",
                     end=" ",
                 )

--- a/src/generation.py
+++ b/src/generation.py
@@ -127,7 +127,7 @@ class Generator:
             if stop_at_eos and (generation[0, -2:] == eos_token_ids).all():
                 print_rank_0("Stopping generation at EOS")
 
-            if print_generation and verbose:
+            if print_generation and verbose and batch_size == 1:
                 print_rank_0(
                     f"{new_idx.item()}",
                     end="-",


### PR DESCRIPTION
Not sure if this is useful, but helpful for my debugging. This prints the integer token id alongside the actual value of the token in the verbose mode. Useful for distinguishing tokens when the token is not ascii (\0 or \3 or something).

We can also wrap this in a flag if you don't want this as default behavior.